### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ $ mv -v example.crt "$(openssl x509 -subject_hash_old -noout -in example.crt)".0
 ```
 
 ### Adding certificates
-1. Copy the certificate file(s) to `/data/misc/user/0/cacerts-custom`.
+1. Copy the certificate file(s) to `/data/misc/user/0/cacerts-custom` (NOT located in your home directory).
 2. Reboot.
 
 ### Removing certificates


### PR DESCRIPTION
Installed the module and immediately went ahead creating `/sdcard/cacerts-custom`, then spend 15 minutes debugging why the certificates weren't added.
Never assume basic user competency, allways assume users skip over 80% of documentation, if they read it at all