### PR TITLE
Fix setting file permissions in post-fs-data.sh

### DIFF
--- a/post-fs-data.sh
+++ b/post-fs-data.sh
@@ -5,4 +5,8 @@ MODDIR=${0%/*}
 mkdir -p $MODDIR/system/etc/security/cacerts
 rm $MODDIR/system/etc/security/cacerts/*
 cp -f /data/misc/user/0/cacerts-custom/* $MODDIR/system/etc/security/cacerts/
-set_perm_recursive $MODDIR/system/etc/security/cacerts/ root root 644
+
+#set_perm_recursive $MODDIR/system/etc/security/cacerts/ root root 644
+#set_perm_recursive $MODDIR/system/etc/security/cacerts 0 0 0755 0644
+chmod 644 $MODDIR/system/etc/security/cacerts/*
+chown root.root $MODDIR/system/etc/security/cacerts/*


### PR DESCRIPTION
My certificate got added with permissions 660, because the original file had those permissions. I assume set_perm_recursive didn't work at all and the owner got changed to root because of the cp. Either way, if the cert files in cacerts-custom end up with the default android file permissions 660, the certs don't work because nothing can read them.
I tried the second line, which is copied straight from  the Fdroid-Priv extension, because those perms got set correctly on my device, but that didn't work here either.

I assume set_perm_recursive isn't available in post-fs-data scripts, only in install.sh.
chmod and chown work fine for me (Android 11 Magisk 24.1)